### PR TITLE
Fixed null AABB crash and gradle wrapper not working.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://repo.wdsj.io/repository/gradle/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/wdsj/homoium/mixin/entity/ticking/MixinEntity.java
+++ b/src/main/java/io/wdsj/homoium/mixin/entity/ticking/MixinEntity.java
@@ -1,7 +1,8 @@
 package io.wdsj.homoium.mixin.entity.ticking;
 
-
+import io.wdsj.homoium.Homoium;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
 import net.minecraft.entity.MoverType;
 import net.minecraft.util.math.AxisAlignedBB;
 import org.spongepowered.asm.mixin.Mixin;
@@ -29,6 +30,11 @@ public abstract class MixinEntity {
 
     @Inject(method = "setEntityBoundingBox", at = @At("HEAD"))
     public void checkBeforeSetAABB(AxisAlignedBB bb, CallbackInfo ci) {
+        if(this.boundingBox == null)
+        {
+            Homoium.LOGGER.warn("ATTENTION, ENTITY " + EntityList.getEntityString((Entity)(Object)this) + " has no AABB contact the mod owner about this.");
+            return;
+        }
         if (!this.boundingBox.equals(bb)) homoium$isBoundingBoxChanged = true;
     }
 

--- a/src/main/java/io/wdsj/homoium/mixin/entity/ticking/MixinEntity.java
+++ b/src/main/java/io/wdsj/homoium/mixin/entity/ticking/MixinEntity.java
@@ -32,7 +32,6 @@ public abstract class MixinEntity {
     public void checkBeforeSetAABB(AxisAlignedBB bb, CallbackInfo ci) {
         if(this.boundingBox == null)
         {
-            Homoium.LOGGER.warn("ATTENTION, ENTITY " + EntityList.getEntityString((Entity)(Object)this) + " has no AABB contact the mod owner about this.");
             return;
         }
         if (!this.boundingBox.equals(bb)) homoium$isBoundingBoxChanged = true;


### PR DESCRIPTION
First of all, thank you for the Minecraft mod.

Anyways, null AABBs were causing crashes, mainly for the Nyx mod. The Nyx mod purposely sets the bounding box of falling entities to null. That caused a crash at the checkBeforeSetAABB mixin when it tried to call its bounding box .equals method.

The other problem is that the gradle wrapper was not working to build the project because the distributionURL in gradle-wrapper.properties was unreachable or expired.

Praise the god version.